### PR TITLE
Add Straight Line modifier key

### DIFF
--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,6 +1,5 @@
 from krita import Krita, Extension  # type: ignore
-from PyQt5.QtWidgets import QToolBar, QApplication, QToolButton, QMenu
-from PyQt5 import QtCore
+from PyQt5.QtWidgets import QToolBar, QToolButton, QMenu
 from PyQt5 import QtGui
 from PyQt5.QtCore import QTimer, QObject, QEvent, Qt
 from functools import partial


### PR DESCRIPTION
Adds event filter that allows a modifier key (currently shift but could be made configurable) to temporarily switch from the freehand brush to line tool, similarly to other paint applications.