### PR TITLE
Link a Brush Preset docker tag with the brush and eraser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ Download [separatebrusheraser.zip](http://github.com/dninosores/krita-separate-b
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 
+# Brush preset tag linking
+
+This is meant to emulate the functionality of the tool preset panel from Photoshop and how clip studio handles brushes.
+
+This option can be enabled by navigating to the settings panels `Tools > Scripts > Brush Eraser Settings` and enabling the checkbox `Link a brush preset tag with the brush and eraser`.
+The Dropdown options below allow you to select which preset tag will be linked with the brush and eraser respectively.
+
+<img width="321" height="175" alt="image" src="https://github.com/user-attachments/assets/d56cfa55-8317-4d74-a1b9-9a887aa4ef85" />

--- a/README.md
+++ b/README.md
@@ -22,11 +22,3 @@ Download [separatebrusheraser.zip](http://github.com/dninosores/krita-separate-b
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 
-# Brush preset tag linking
-
-This is meant to emulate the functionality of the tool preset panel from Photoshop and how clip studio handles brushes.
-
-This option can be enabled by navigating to the settings panels `Tools > Scripts > Brush Eraser Settings` and enabling the checkbox `Link a brush preset tag with the brush and eraser`.
-The Dropdown options below allow you to select which preset tag will be linked with the brush and eraser respectively.
-
-<img width="321" height="175" alt="image" src="https://github.com/user-attachments/assets/d56cfa55-8317-4d74-a1b9-9a887aa4ef85" />

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you click the eraser in the top bar, the eraser will toggle on/off for the cu
 
 ## Installation
 
-Download [separatebrusheraser.zip](http://github.com/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
+Download [separatebrusheraser.zip](http://github.com/dninosores/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you click the eraser in the top bar, the eraser will toggle on/off for the cu
 
 ## Installation
 
-Download [separatebrusheraser.zip](http://github.com/dninosores/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
+Download [separatebrusheraser.zip](http://github.com/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you click the eraser in the top bar, the eraser will toggle on/off for the cu
 
 ## Installation
 
-Download [separatebrusheraser.zip](http://github.com/dninosores/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
+Download [separatebrusheraser.zip](http://github.com/dninosores/krita-separate-brush-eraser/releases/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you click the eraser in the top bar, the eraser will toggle on/off for the cu
 
 ## Installation
 
-Download [separatebrusheraser.zip](http://github.com/dninosores/krita-separate-brush-eraser/releases/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
+Download [separatebrusheraser.zip](http://github.com/dninosores/Bliwi/krita-separate-brush-eraser/latest/download/separatebrusheraser.zip) and install by going to `Tools > Scripts > Import Python Plugin From File...` in Krita and selecting the zip file.
 
 If you're having issues, more information on plugin installation can be found [here](https://docs.krita.org/en/user_manual/python_scripting/install_custom_python_plugin.html).
 

--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,9 +1,10 @@
-from krita import *
-from PyQt5.QtWidgets import QWidget, QAction, QComboBox,  QCheckBox, QVBoxLayout, QLineEdit, QPushButton, QLabel
-from PyQt5.QtCore import QSettings
+from krita import Krita, Extension  # type: ignore
+from PyQt5.QtWidgets import QToolBar, QToolButton, QMenu
+from PyQt5 import QtGui
+from PyQt5.QtCore import QTimer, QObject, QEvent, Qt
 from functools import partial
-from pprint import pprint
 from .api_krita import Krita as KritaAPI
+from .api_krita.enums import Tool
 
 KRITA_ERASE_ACTION = "erase_action"
 BRUSH_ACTION = "dninosores_activate_brush"
@@ -12,15 +13,22 @@ ERASE_ON_ACTION = "dninosores_eraser_on"
 ERASE_OFF_ACTION = "dninosores_eraser_off"
 ERASE_TOGGLE_ACTION = "dninosores_eraser_toggle"
 MENU_LOCATION = "tools/scripts"
+MENU_GROUP_NAME = "SeparateBrushEraser"
 BRUSH_MODE = "BRUSH"
 ERASER_MODE = "ERASER"
 
-DEBUG = True
+DEBUG = False
 
 
 def print_dbg(msg):
     if DEBUG:
         print(msg)
+
+
+def get_action(name: str):
+    """Wrapper for non-type-safe getting action from Krita instance."""
+    return Krita.instance().action(name)
+
 
 class BrushSettings:
 
@@ -42,39 +50,28 @@ class BrushSettings:
 class BrushState:
     # Store a brush state for each view
     eraser_on: bool = False
-    brush_settings: BrushSettings = None
-    eraser_settings: BrushSettings = None
+    brush_settings: BrushSettings | None = None
+    eraser_settings: BrushSettings | None = None
 
 
 class SeparateBrushEraserExtension(Extension):
     brush_state = None
-    # In SeparateBrushEraserExtension class definition
-    settings = QSettings("ollyisonit", "SeparateBrushEraser")
-
+    # Toggled on when the line tool is temporarily activated by modifier key
+    tmp_line_activation: bool = False
 
     def __init__(self, parent):
         super().__init__(parent)
+        self.filter = LineModifierFilter(self, Qt.Key.Key_Shift)
 
     def switch_to_brush(self):
-        Krita.instance().action("KritaShape/KisToolBrush").trigger()
+        KritaAPI.trigger_action("KritaShape/KisToolBrush")
 
     def eraser_active(self):
-        return Application.action(KRITA_ERASE_ACTION).isChecked()
-
-    # Big thanks to AkiR for helping with this function
-    def set_brush_preset_combo_box(self, tag):
-        app = Krita.instance()
-        win = app.activeWindow()
-        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
-        for combo_box in presets_docker.findChildren(QComboBox):
-            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
-                # print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
-                combo_box.setCurrentText(tag)
-                return  # correct one found, break loop with return
+        return get_action(KRITA_ERASE_ACTION).isChecked()
 
     def get_current_brush_state(self):
-        if (not KritaAPI.get_active_view() or not Application.activeWindow().
-                activeView().currentBrushPreset()):
+        if (not KritaAPI.get_active_view() or not Krita.instance().
+                activeWindow().activeView().currentBrushPreset()):
             return None
         if self.brush_state:
             return self.brush_state
@@ -94,74 +91,68 @@ class SeparateBrushEraserExtension(Extension):
         current_settings = BrushSettings().loadSettings()
         # toggling the eraser on
         if state.eraser_on:
-            state.eraser_settings.applySettings()
+            if state.eraser_settings:
+                state.eraser_settings.applySettings()
             state.brush_settings = current_settings
         else:
             state.eraser_settings = current_settings
-            state.brush_settings.applySettings()
+            if state.brush_settings:
+                state.brush_settings.applySettings()
         self.verify_eraser_state()
         return state
 
     def apply_current_brush_state(self):
-        return self.apply_brush_state(self.get_current_brush_state())
+        state = self.get_current_brush_state()
+        if state:
+            return self.apply_brush_state(state)
 
     def activate_brush(self, switchTool=True):
-        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
-        brush_tag = self.settings.value("brush_dropdown", "")
-
         if not self.get_current_brush_state():
             return
-        if link_brush_tag:
-            self.set_brush_preset_combo_box(brush_tag)
-        self.get_current_brush_state().eraser_on = False
+        self.get_current_brush_state().eraser_on = False  # type: ignore
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def activate_eraser(self, switchTool=True):
-        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
-        eraser_tag = self.settings.value("eraser_dropdown", "")
-
         if not self.get_current_brush_state():
             return
-        # print("Switching to eraser mode")  # Added logging
-        if link_brush_tag:
-            self.set_brush_preset_combo_box(eraser_tag)
-        self.get_current_brush_state().eraser_on = True
+        self.get_current_brush_state().eraser_on = True  # type: ignore
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def on_brush_toggled(self, toggled):
-        if not self.get_current_brush_state():
+        current_brush_state = self.get_current_brush_state()
+        if not current_brush_state:
             return
         # Triggers when krita switches to/from the brush tool for any reason. Does not trigger if the brush tool is already selected.
         if toggled:
             pass
-        elif QApplication.queryKeyboardModifiers() & Qt.ShiftModifier:
+        # Don't switch eraser state if we're activating the line tool temporarily with modifier key
+        elif self.tmp_line_activation:
             pass
-            print("Keeping eraser on bc shift is down")
         else:
-            print("Turning off eraser bc shift is not down")
-            self.get_current_brush_state().eraser_on = False
+            current_brush_state.eraser_on = False
             self.apply_current_brush_state()
 
     def verify_eraser_state(self):
-        if self.get_current_brush_state():
-            desired_state = self.get_current_brush_state().eraser_on
+        current_brush_state = self.get_current_brush_state()
+        if current_brush_state:
+            desired_state = current_brush_state.eraser_on
             if desired_state != self.eraser_active():
-                Application.action(KRITA_ERASE_ACTION).trigger()
+                KritaAPI.trigger_action(KRITA_ERASE_ACTION)
 
     def on_eraser_action(self, toggled):
         pass
         # self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
-        print("changed to the eraser")
 
     def classic_krita_eraser_toggle_auto(self):
-        self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
+        if self.brush_state:
+            self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
 
     def classic_krita_eraser_toggle(self, toggled):
         # self.verify_eraser_state()
@@ -172,52 +163,51 @@ class SeparateBrushEraserExtension(Extension):
             self.activate_brush(False)
 
     def on_eraser_button_clicked(self, toggled):
-        print(f"Clicked with value {toggled}")
+        # print(f"Clicked with value {toggled}")
         # Actually I think it would be better if this toggled like regular krita
         # i.e. swap the brush presets, then toggle eraser without switching tool
         # actually don't swap the brush presets but to toggle eraser without switching tool
         self.classic_krita_eraser_toggle(toggled)
 
     def on_eraser_button_toggled(self, toggled):
-        print(f"Button toggled with value {toggled}")
-        self.get_eraser_button().setChecked(self.eraser_active())
+        # print(f"Button toggled with value {toggled}")'
+        eraser_button = self.get_eraser_button()
+        if eraser_button:
+            eraser_button.setChecked(self.eraser_active())
         # self.verify_eraser_state()
 
     def setup(self):
         pass
 
-    def open_settings_window(self):
-        self.settings_window = SettingsWindow()
-        self.settings_window.show()
-
     def createActions(self, window):
-        # Add this new action with the existing actions
-        settings_action = window.createAction(
-            "dninosores_brush_eraser_settings",
-            "Brush Eraser Settings",
-            MENU_LOCATION)
-        settings_action.triggered.connect(self.open_settings_window)
-        
+
+        # menu = QMenu(MENU_GROUP_NAME, window.qwindow())
         # actions should be:
         # Switch to brush / switch to eraser, which activate the brush tool
         # Activate brush / eraser, which switch without activating the brush tool
         # Toggle, which toggles between the two options without switching the tool
         # A 'when you hold shift temporarily switch to the line tool without deactivating eraser' action
-        activate_brush_action = window.createAction(BRUSH_ACTION,
-                                                    "Switch to Brush",
-                                                    MENU_LOCATION)
-        activate_eraser_action = window.createAction(ERASE_ACTION,
-                                                     "Switch to Eraser",
-                                                     MENU_LOCATION)
-        enable_eraser_action = window.createAction(ERASE_ON_ACTION,
-                                                   "Activate Eraser",
-                                                   MENU_LOCATION)
-        disable_eraser_action = window.createAction(ERASE_OFF_ACTION,
-                                                    "Deactivate Eraser",
-                                                    MENU_LOCATION)
-        toggle_eraser_action = window.createAction(ERASE_TOGGLE_ACTION,
-                                                   "Toggle Eraser",
-                                                   MENU_LOCATION)
+        menu_action = window.createAction(
+            MENU_GROUP_NAME, MENU_GROUP_NAME,
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        menu = QMenu(MENU_GROUP_NAME, window.qwindow())
+        menu_action.setMenu(menu)
+        activate_brush_action = window.createAction(
+            BRUSH_ACTION, "Switch to Freehand Brush",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        activate_eraser_action = window.createAction(
+            ERASE_ACTION, "Switch to Freehand Eraser",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        enable_eraser_action = window.createAction(
+            ERASE_ON_ACTION, "Activate Eraser Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        disable_eraser_action = window.createAction(
+            ERASE_OFF_ACTION, "Activate Brush Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        toggle_eraser_action = window.createAction(
+            ERASE_TOGGLE_ACTION, "Toggle Eraser Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+
         activate_brush_action.triggered.connect(
             partial(self.activate_brush, True))
         activate_eraser_action.triggered.connect(
@@ -229,32 +219,49 @@ class SeparateBrushEraserExtension(Extension):
         toggle_eraser_action.triggered.connect(
             self.classic_krita_eraser_toggle_auto)
 
+        appNotifier = KritaAPI.instance.notifier()
+        appNotifier.setActive(True)
+
+        def installLineModifierFilter(_view: QObject):
+            for item, level in IterHierarchy(
+                    KritaAPI.instance.activeWindow().qwindow()):
+                if item.metaObject().className() == "Viewport":
+                    print_dbg("Installing line modifier filter")
+                    item.removeEventFilter(self.filter)
+                    item.installEventFilter(self.filter)
+
+        appNotifier.viewCreated.connect(installLineModifierFilter)
+
         QTimer.singleShot(500, self.bind_brush_toggled)
 
-    def get_eraser_button(self):
-        qwin = Application.activeWindow().qwindow()
+    def get_eraser_button(self) -> QToolButton | None:
+        qwin = KritaAPI.get_active_qwindow()
         pobj = qwin.findChild(QToolBar, 'BrushesAndStuff')
         eraser_button = None
         for item, depth in IterHierarchy(pobj):
             try:
-                if item.defaultAction() == Application.action(
-                        KRITA_ERASE_ACTION):
+                if item.defaultAction() == get_action(KRITA_ERASE_ACTION):
                     eraser_button = item
-            except:
+            except Exception:
                 pass
         return eraser_button
 
     def print_state(self):
-        if self.get_current_brush_state():
-            desired_state = self.get_current_brush_state().eraser_on
+        current_brush_state = self.get_current_brush_state()
+        eraser_button = self.get_eraser_button()
+        if current_brush_state:
+            desired_state = current_brush_state.eraser_on
             print(f"Eraser should be {desired_state}")
-            print(f"Button checked is {self.get_eraser_button().isChecked()}")
+            if eraser_button:
+                print(f"Button checked is {eraser_button.isChecked()}")
+            else:
+                print("Eraser button not found!")
             print(f"Eraser action is {self.eraser_active()}")
             print("\n")
 
     def bind_brush_toggled(self):
         success = False
-        Application.action(KRITA_ERASE_ACTION).triggered.connect(
+        Krita.instance().action(KRITA_ERASE_ACTION).triggered.connect(
             self.on_eraser_action)
         for docker in Krita.instance().dockers():
             if docker.objectName() == "ToolBox":
@@ -268,13 +275,44 @@ class SeparateBrushEraserExtension(Extension):
                 "Binding eraser toggle to brush button failed. Try restarting Krita."
             )
         eraser_button = self.get_eraser_button()
-
-        eraser_button.toggled.connect(self.on_eraser_button_toggled)
-        eraser_button.clicked.connect(self.on_eraser_button_clicked)
-
-        timer = QTimer(Application.activeWindow().qwindow())
+        if eraser_button:
+            eraser_button.toggled.connect(self.on_eraser_button_toggled)
+            eraser_button.clicked.connect(self.on_eraser_button_clicked)
+        else:
+            print(
+                "Binding eraser toggle to erase button failed. Try restarting Krita."
+            )
+        timer = QTimer(KritaAPI.get_active_qwindow())
         timer.timeout.connect(self.verify_eraser_state)
         timer.start(1)
+
+
+class LineModifierFilter(QObject):
+    """EventFilter that listens for a certain modifier key and tells the extension to temporarily switch to the line tool when it the key is pressed."""
+    extension: SeparateBrushEraserExtension
+    modifier_key: int = Qt.Key.Key_Shift
+
+    def __init__(self, extension: SeparateBrushEraserExtension,
+                 modifier_key: int):
+        super().__init__()
+        self.extension = extension
+        self.modifier_key = modifier_key
+
+    def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
+        event = a1
+        if event and isinstance(event, QtGui.QKeyEvent):
+            if KritaAPI.active_tool == Tool.FREEHAND_BRUSH and event.key(
+            ) == self.modifier_key and event.type() == QEvent.Type.KeyPress:
+                print_dbg("event filter activated")
+                self.extension.tmp_line_activation = True
+                KritaAPI.active_tool = Tool.LINE
+            if KritaAPI.active_tool == Tool.LINE and event.key(
+            ) == self.modifier_key and event.type() == QEvent.Type.KeyRelease:
+                print_dbg("event filter activated")
+                if self.extension.tmp_line_activation:
+                    KritaAPI.active_tool = Tool.FREEHAND_BRUSH
+                    self.extension.tmp_line_activation = False
+        return False
 
 
 class IterHierarchy:
@@ -303,75 +341,3 @@ class IterHierarchy:
 
 
 Krita.instance().addExtension(SeparateBrushEraserExtension(Krita.instance()))
-
-# Add after imports, before other classes
-class SettingsWindow(QWidget):
-    
-    def read_brush_preset_combo_box(self):
-        app = Krita.instance()
-        win = app.activeWindow()
-        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
-        for combo_box in presets_docker.findChildren(QComboBox):
-            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
-                return [combo_box.itemText(i) for i in range(combo_box.count())]
-
-    def __init__(self):
-        super().__init__()
-        preset_tags = self.read_brush_preset_combo_box()
-        self.settings = QSettings("ollyisonit", "SeparateBrushEraser")
-        self.setWindowTitle("Separate Brush Eraser Settings")
-        # Removed setGeometry – we’ll let size policies handle layout
-        # self.setGeometry(100, 100, 300, 200)
-
-        main_layout = QVBoxLayout()
-
-        # Checkbox
-        self.checkbox = QCheckBox("Link a brush preset tag with the brush and eraser")
-        self.checkbox.setChecked(self.settings.value("checkbox_state", False, type=bool))
-        self.checkbox.stateChanged.connect(self.on_checkbox_state_changed)
-        main_layout.addWidget(self.checkbox)
-
-        # Brush section
-        brush_label = QLabel("Brush preset tag to link with brushes:")
-        self.brush_dropdown = QComboBox()
-        self.brush_dropdown.addItems(preset_tags)
-        saved_brush = self.settings.value("brush_dropdown", "")
-        if saved_brush and saved_brush in preset_tags:
-            self.brush_dropdown.setCurrentText(saved_brush)
-        self.brush_dropdown.currentTextChanged.connect(self.on_brush_changed)
-
-        # Apply fixed size policy
-        brush_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.brush_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
-        main_layout.addWidget(brush_label)
-        main_layout.addWidget(self.brush_dropdown)
-
-        # Eraser section
-        eraser_label = QLabel("Brush preset tag to link with erasers:")
-        self.eraser_dropdown = QComboBox()
-        self.eraser_dropdown.addItems(preset_tags)
-        saved_eraser = self.settings.value("eraser_dropdown", "")
-        if saved_eraser and saved_eraser in preset_tags:
-            self.eraser_dropdown.setCurrentText(saved_eraser)
-        self.eraser_dropdown.currentTextChanged.connect(self.on_eraser_changed)
-
-        # Apply fixed size policy
-        eraser_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-        self.eraser_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
-        main_layout.addWidget(eraser_label)
-        main_layout.addWidget(self.eraser_dropdown)
-
-        # Set layout and let it autosize
-        self.setLayout(main_layout)
-        self.adjustSize()
-
-    def on_checkbox_state_changed(self, state):
-        self.settings.setValue("checkbox_state", bool(state))
-
-    def on_brush_changed(self, value):
-        self.settings.setValue("brush_dropdown", value)
-
-    def on_eraser_changed(self, value):
-        self.settings.setValue("eraser_dropdown", value)

--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,8 +1,10 @@
-from krita import *
-from PyQt5.QtWidgets import QWidget, QAction, QComboBox
+from krita import Krita, Extension  # type: ignore
+from PyQt5.QtWidgets import QToolBar, QToolButton, QMenu
+from PyQt5 import QtGui
+from PyQt5.QtCore import QTimer, QObject, QEvent, Qt
 from functools import partial
-from pprint import pprint
 from .api_krita import Krita as KritaAPI
+from .api_krita.enums import Tool
 
 KRITA_ERASE_ACTION = "erase_action"
 BRUSH_ACTION = "dninosores_activate_brush"
@@ -11,16 +13,22 @@ ERASE_ON_ACTION = "dninosores_eraser_on"
 ERASE_OFF_ACTION = "dninosores_eraser_off"
 ERASE_TOGGLE_ACTION = "dninosores_eraser_toggle"
 MENU_LOCATION = "tools/scripts"
+MENU_GROUP_NAME = "SeparateBrushEraser"
 BRUSH_MODE = "BRUSH"
 ERASER_MODE = "ERASER"
 
-DEBUG = True
+DEBUG = False
 
 
 def print_dbg(msg):
     if DEBUG:
         print(msg)
-        print("hello World!")
+
+
+def get_action(name: str):
+    """Wrapper for non-type-safe getting action from Krita instance."""
+    return Krita.instance().action(name)
+
 
 class BrushSettings:
 
@@ -42,36 +50,28 @@ class BrushSettings:
 class BrushState:
     # Store a brush state for each view
     eraser_on: bool = False
-    brush_settings: BrushSettings = None
-    eraser_settings: BrushSettings = None
+    brush_settings: BrushSettings | None = None
+    eraser_settings: BrushSettings | None = None
 
 
 class SeparateBrushEraserExtension(Extension):
     brush_state = None
+    # Toggled on when the line tool is temporarily activated by modifier key
+    tmp_line_activation: bool = False
 
     def __init__(self, parent):
         super().__init__(parent)
+        self.filter = LineModifierFilter(self, Qt.Key.Key_Shift)
 
     def switch_to_brush(self):
-        Krita.instance().action("KritaShape/KisToolBrush").trigger()
+        KritaAPI.trigger_action("KritaShape/KisToolBrush")
 
     def eraser_active(self):
-        return Application.action(KRITA_ERASE_ACTION).isChecked()
-
-    # Big thankts to AkiR for helping with this function!
-    def set_brush_preset_combo_box(self, tag):
-        app = Krita.instance()
-        win = app.activeWindow()
-        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
-        for combo_box in presets_docker.findChildren(QComboBox):
-            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
-                print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
-                combo_box.setCurrentText(tag)
-                return  # correct one found, break loop with return
+        return get_action(KRITA_ERASE_ACTION).isChecked()
 
     def get_current_brush_state(self):
-        if (not KritaAPI.get_active_view() or not Application.activeWindow().
-                activeView().currentBrushPreset()):
+        if (not KritaAPI.get_active_view() or not Krita.instance().
+                activeWindow().activeView().currentBrushPreset()):
             return None
         if self.brush_state:
             return self.brush_state
@@ -91,24 +91,25 @@ class SeparateBrushEraserExtension(Extension):
         current_settings = BrushSettings().loadSettings()
         # toggling the eraser on
         if state.eraser_on:
-            state.eraser_settings.applySettings()
+            if state.eraser_settings:
+                state.eraser_settings.applySettings()
             state.brush_settings = current_settings
         else:
             state.eraser_settings = current_settings
-            state.brush_settings.applySettings()
+            if state.brush_settings:
+                state.brush_settings.applySettings()
         self.verify_eraser_state()
         return state
 
     def apply_current_brush_state(self):
-        return self.apply_brush_state(self.get_current_brush_state())
+        state = self.get_current_brush_state()
+        if state:
+            return self.apply_brush_state(state)
 
     def activate_brush(self, switchTool=True):
         if not self.get_current_brush_state():
             return
-        print("Switching to brush mode")
-        # set_brush_preset_combo_box('Digital')
-        self.set_brush_preset_combo_box('Brushes')
-        self.get_current_brush_state().eraser_on = False
+        self.get_current_brush_state().eraser_on = False  # type: ignore
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
@@ -117,42 +118,41 @@ class SeparateBrushEraserExtension(Extension):
     def activate_eraser(self, switchTool=True):
         if not self.get_current_brush_state():
             return
-        print("Switching to eraser mode")  # Added logging
-        self.set_brush_preset_combo_box('Erasers')
-        self.get_current_brush_state().eraser_on = True
+        self.get_current_brush_state().eraser_on = True  # type: ignore
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def on_brush_toggled(self, toggled):
-        if not self.get_current_brush_state():
+        current_brush_state = self.get_current_brush_state()
+        if not current_brush_state:
             return
         # Triggers when krita switches to/from the brush tool for any reason. Does not trigger if the brush tool is already selected.
         if toggled:
             pass
-        elif QApplication.queryKeyboardModifiers() & Qt.ShiftModifier:
+        # Don't switch eraser state if we're activating the line tool temporarily with modifier key
+        elif self.tmp_line_activation:
             pass
-            print("Keeping eraser on bc shift is down")
         else:
-            print("Turning off eraser bc shift is not down")
-            self.get_current_brush_state().eraser_on = False
+            current_brush_state.eraser_on = False
             self.apply_current_brush_state()
 
     def verify_eraser_state(self):
-        if self.get_current_brush_state():
-            desired_state = self.get_current_brush_state().eraser_on
+        current_brush_state = self.get_current_brush_state()
+        if current_brush_state:
+            desired_state = current_brush_state.eraser_on
             if desired_state != self.eraser_active():
-                Application.action(KRITA_ERASE_ACTION).trigger()
+                KritaAPI.trigger_action(KRITA_ERASE_ACTION)
 
     def on_eraser_action(self, toggled):
         pass
         # self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
-        print("changed to the eraser")
 
     def classic_krita_eraser_toggle_auto(self):
-        self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
+        if self.brush_state:
+            self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
 
     def classic_krita_eraser_toggle(self, toggled):
         # self.verify_eraser_state()
@@ -163,41 +163,51 @@ class SeparateBrushEraserExtension(Extension):
             self.activate_brush(False)
 
     def on_eraser_button_clicked(self, toggled):
-        print(f"Clicked with value {toggled}")
+        # print(f"Clicked with value {toggled}")
         # Actually I think it would be better if this toggled like regular krita
         # i.e. swap the brush presets, then toggle eraser without switching tool
         # actually don't swap the brush presets but to toggle eraser without switching tool
         self.classic_krita_eraser_toggle(toggled)
 
     def on_eraser_button_toggled(self, toggled):
-        print(f"Button toggled with value {toggled}")
-        self.get_eraser_button().setChecked(self.eraser_active())
+        # print(f"Button toggled with value {toggled}")'
+        eraser_button = self.get_eraser_button()
+        if eraser_button:
+            eraser_button.setChecked(self.eraser_active())
         # self.verify_eraser_state()
 
     def setup(self):
         pass
 
     def createActions(self, window):
+
+        # menu = QMenu(MENU_GROUP_NAME, window.qwindow())
         # actions should be:
         # Switch to brush / switch to eraser, which activate the brush tool
         # Activate brush / eraser, which switch without activating the brush tool
         # Toggle, which toggles between the two options without switching the tool
         # A 'when you hold shift temporarily switch to the line tool without deactivating eraser' action
-        activate_brush_action = window.createAction(BRUSH_ACTION,
-                                                    "Switch to Brush",
-                                                    MENU_LOCATION)
-        activate_eraser_action = window.createAction(ERASE_ACTION,
-                                                     "Switch to Eraser",
-                                                     MENU_LOCATION)
-        enable_eraser_action = window.createAction(ERASE_ON_ACTION,
-                                                   "Activate Eraser",
-                                                   MENU_LOCATION)
-        disable_eraser_action = window.createAction(ERASE_OFF_ACTION,
-                                                    "Deactivate Eraser",
-                                                    MENU_LOCATION)
-        toggle_eraser_action = window.createAction(ERASE_TOGGLE_ACTION,
-                                                   "Toggle Eraser",
-                                                   MENU_LOCATION)
+        menu_action = window.createAction(
+            MENU_GROUP_NAME, MENU_GROUP_NAME,
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        menu = QMenu(MENU_GROUP_NAME, window.qwindow())
+        menu_action.setMenu(menu)
+        activate_brush_action = window.createAction(
+            BRUSH_ACTION, "Switch to Freehand Brush",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        activate_eraser_action = window.createAction(
+            ERASE_ACTION, "Switch to Freehand Eraser",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        enable_eraser_action = window.createAction(
+            ERASE_ON_ACTION, "Activate Eraser Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        disable_eraser_action = window.createAction(
+            ERASE_OFF_ACTION, "Activate Brush Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+        toggle_eraser_action = window.createAction(
+            ERASE_TOGGLE_ACTION, "Toggle Eraser Preset for Current Tool",
+            MENU_LOCATION + "/" + MENU_GROUP_NAME)
+
         activate_brush_action.triggered.connect(
             partial(self.activate_brush, True))
         activate_eraser_action.triggered.connect(
@@ -209,32 +219,49 @@ class SeparateBrushEraserExtension(Extension):
         toggle_eraser_action.triggered.connect(
             self.classic_krita_eraser_toggle_auto)
 
+        appNotifier = KritaAPI.instance.notifier()
+        appNotifier.setActive(True)
+
+        def installLineModifierFilter(_view: QObject):
+            for item, level in IterHierarchy(
+                    KritaAPI.instance.activeWindow().qwindow()):
+                if item.metaObject().className() == "Viewport":
+                    print_dbg("Installing line modifier filter")
+                    item.removeEventFilter(self.filter)
+                    item.installEventFilter(self.filter)
+
+        appNotifier.viewCreated.connect(installLineModifierFilter)
+
         QTimer.singleShot(500, self.bind_brush_toggled)
 
-    def get_eraser_button(self):
-        qwin = Application.activeWindow().qwindow()
+    def get_eraser_button(self) -> QToolButton | None:
+        qwin = KritaAPI.get_active_qwindow()
         pobj = qwin.findChild(QToolBar, 'BrushesAndStuff')
         eraser_button = None
         for item, depth in IterHierarchy(pobj):
             try:
-                if item.defaultAction() == Application.action(
-                        KRITA_ERASE_ACTION):
+                if item.defaultAction() == get_action(KRITA_ERASE_ACTION):
                     eraser_button = item
-            except:
+            except Exception:
                 pass
         return eraser_button
 
     def print_state(self):
-        if self.get_current_brush_state():
-            desired_state = self.get_current_brush_state().eraser_on
+        current_brush_state = self.get_current_brush_state()
+        eraser_button = self.get_eraser_button()
+        if current_brush_state:
+            desired_state = current_brush_state.eraser_on
             print(f"Eraser should be {desired_state}")
-            print(f"Button checked is {self.get_eraser_button().isChecked()}")
+            if eraser_button:
+                print(f"Button checked is {eraser_button.isChecked()}")
+            else:
+                print("Eraser button not found!")
             print(f"Eraser action is {self.eraser_active()}")
             print("\n")
 
     def bind_brush_toggled(self):
         success = False
-        Application.action(KRITA_ERASE_ACTION).triggered.connect(
+        Krita.instance().action(KRITA_ERASE_ACTION).triggered.connect(
             self.on_eraser_action)
         for docker in Krita.instance().dockers():
             if docker.objectName() == "ToolBox":
@@ -248,13 +275,44 @@ class SeparateBrushEraserExtension(Extension):
                 "Binding eraser toggle to brush button failed. Try restarting Krita."
             )
         eraser_button = self.get_eraser_button()
-
-        eraser_button.toggled.connect(self.on_eraser_button_toggled)
-        eraser_button.clicked.connect(self.on_eraser_button_clicked)
-
-        timer = QTimer(Application.activeWindow().qwindow())
+        if eraser_button:
+            eraser_button.toggled.connect(self.on_eraser_button_toggled)
+            eraser_button.clicked.connect(self.on_eraser_button_clicked)
+        else:
+            print(
+                "Binding eraser toggle to erase button failed. Try restarting Krita."
+            )
+        timer = QTimer(KritaAPI.get_active_qwindow())
         timer.timeout.connect(self.verify_eraser_state)
         timer.start(1)
+
+
+class LineModifierFilter(QObject):
+    """EventFilter that listens for a certain modifier key and tells the extension to temporarily switch to the line tool when it the key is pressed."""
+    extension: SeparateBrushEraserExtension
+    modifier_key: int = Qt.Key.Key_Shift
+
+    def __init__(self, extension: SeparateBrushEraserExtension,
+                 modifier_key: int):
+        super().__init__()
+        self.extension = extension
+        self.modifier_key = modifier_key
+
+    def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
+        event = a1
+        if event and isinstance(event, QtGui.QKeyEvent):
+            if KritaAPI.active_tool == Tool.FREEHAND_BRUSH and event.key(
+            ) == self.modifier_key and event.type() == QEvent.Type.KeyPress:
+                print_dbg("event filter activated")
+                self.extension.tmp_line_activation = True
+                KritaAPI.active_tool = Tool.LINE
+            if KritaAPI.active_tool == Tool.LINE and event.key(
+            ) == self.modifier_key and event.type() == QEvent.Type.KeyRelease:
+                print_dbg("event filter activated")
+                if self.extension.tmp_line_activation:
+                    KritaAPI.active_tool = Tool.FREEHAND_BRUSH
+                    self.extension.tmp_line_activation = False
+        return False
 
 
 class IterHierarchy:

--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,5 +1,6 @@
 from krita import *
-from PyQt5.QtWidgets import QWidget, QAction, QComboBox
+from PyQt5.QtWidgets import QWidget, QAction, QComboBox,  QCheckBox, QVBoxLayout, QLineEdit, QPushButton, QLabel
+from PyQt5.QtCore import QSettings
 from functools import partial
 from pprint import pprint
 from .api_krita import Krita as KritaAPI
@@ -20,7 +21,6 @@ DEBUG = True
 def print_dbg(msg):
     if DEBUG:
         print(msg)
-        print("hello World!")
 
 class BrushSettings:
 
@@ -48,6 +48,9 @@ class BrushState:
 
 class SeparateBrushEraserExtension(Extension):
     brush_state = None
+    # In SeparateBrushEraserExtension class definition
+    settings = QSettings("ollyisonit", "SeparateBrushEraser")
+
 
     def __init__(self, parent):
         super().__init__(parent)
@@ -58,14 +61,14 @@ class SeparateBrushEraserExtension(Extension):
     def eraser_active(self):
         return Application.action(KRITA_ERASE_ACTION).isChecked()
 
-    # Big thankts to AkiR for helping with this function!
+    # Big thanks to AkiR for helping with this function
     def set_brush_preset_combo_box(self, tag):
         app = Krita.instance()
         win = app.activeWindow()
         presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
         for combo_box in presets_docker.findChildren(QComboBox):
             if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
-                print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
+                # print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
                 combo_box.setCurrentText(tag)
                 return  # correct one found, break loop with return
 
@@ -103,11 +106,13 @@ class SeparateBrushEraserExtension(Extension):
         return self.apply_brush_state(self.get_current_brush_state())
 
     def activate_brush(self, switchTool=True):
+        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
+        brush_tag = self.settings.value("brush_dropdown", "")
+
         if not self.get_current_brush_state():
             return
-        print("Switching to brush mode")
-        # set_brush_preset_combo_box('Digital')
-        self.set_brush_preset_combo_box('Brushes')
+        if link_brush_tag:
+            self.set_brush_preset_combo_box(brush_tag)
         self.get_current_brush_state().eraser_on = False
         if switchTool:
             self.switch_to_brush()
@@ -115,10 +120,14 @@ class SeparateBrushEraserExtension(Extension):
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def activate_eraser(self, switchTool=True):
+        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
+        eraser_tag = self.settings.value("eraser_dropdown", "")
+
         if not self.get_current_brush_state():
             return
-        print("Switching to eraser mode")  # Added logging
-        self.set_brush_preset_combo_box('Erasers')
+        # print("Switching to eraser mode")  # Added logging
+        if link_brush_tag:
+            self.set_brush_preset_combo_box(eraser_tag)
         self.get_current_brush_state().eraser_on = True
         if switchTool:
             self.switch_to_brush()
@@ -177,7 +186,18 @@ class SeparateBrushEraserExtension(Extension):
     def setup(self):
         pass
 
+    def open_settings_window(self):
+        self.settings_window = SettingsWindow()
+        self.settings_window.show()
+
     def createActions(self, window):
+        # Add this new action with the existing actions
+        settings_action = window.createAction(
+            "dninosores_brush_eraser_settings",
+            "Brush Eraser Settings",
+            MENU_LOCATION)
+        settings_action.triggered.connect(self.open_settings_window)
+        
         # actions should be:
         # Switch to brush / switch to eraser, which activate the brush tool
         # Activate brush / eraser, which switch without activating the brush tool
@@ -283,3 +303,75 @@ class IterHierarchy:
 
 
 Krita.instance().addExtension(SeparateBrushEraserExtension(Krita.instance()))
+
+# Add after imports, before other classes
+class SettingsWindow(QWidget):
+    
+    def read_brush_preset_combo_box(self):
+        app = Krita.instance()
+        win = app.activeWindow()
+        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
+        for combo_box in presets_docker.findChildren(QComboBox):
+            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
+                return [combo_box.itemText(i) for i in range(combo_box.count())]
+
+    def __init__(self):
+        super().__init__()
+        preset_tags = self.read_brush_preset_combo_box()
+        self.settings = QSettings("ollyisonit", "SeparateBrushEraser")
+        self.setWindowTitle("Separate Brush Eraser Settings")
+        # Removed setGeometry – we’ll let size policies handle layout
+        # self.setGeometry(100, 100, 300, 200)
+
+        main_layout = QVBoxLayout()
+
+        # Checkbox
+        self.checkbox = QCheckBox("Link a brush preset tag with the brush and eraser")
+        self.checkbox.setChecked(self.settings.value("checkbox_state", False, type=bool))
+        self.checkbox.stateChanged.connect(self.on_checkbox_state_changed)
+        main_layout.addWidget(self.checkbox)
+
+        # Brush section
+        brush_label = QLabel("Brush preset tag to link with brushes:")
+        self.brush_dropdown = QComboBox()
+        self.brush_dropdown.addItems(preset_tags)
+        saved_brush = self.settings.value("brush_dropdown", "")
+        if saved_brush and saved_brush in preset_tags:
+            self.brush_dropdown.setCurrentText(saved_brush)
+        self.brush_dropdown.currentTextChanged.connect(self.on_brush_changed)
+
+        # Apply fixed size policy
+        brush_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.brush_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        main_layout.addWidget(brush_label)
+        main_layout.addWidget(self.brush_dropdown)
+
+        # Eraser section
+        eraser_label = QLabel("Brush preset tag to link with erasers:")
+        self.eraser_dropdown = QComboBox()
+        self.eraser_dropdown.addItems(preset_tags)
+        saved_eraser = self.settings.value("eraser_dropdown", "")
+        if saved_eraser and saved_eraser in preset_tags:
+            self.eraser_dropdown.setCurrentText(saved_eraser)
+        self.eraser_dropdown.currentTextChanged.connect(self.on_eraser_changed)
+
+        # Apply fixed size policy
+        eraser_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.eraser_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        main_layout.addWidget(eraser_label)
+        main_layout.addWidget(self.eraser_dropdown)
+
+        # Set layout and let it autosize
+        self.setLayout(main_layout)
+        self.adjustSize()
+
+    def on_checkbox_state_changed(self, state):
+        self.settings.setValue("checkbox_state", bool(state))
+
+    def on_brush_changed(self, value):
+        self.settings.setValue("brush_dropdown", value)
+
+    def on_eraser_changed(self, value):
+        self.settings.setValue("eraser_dropdown", value)

--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,10 +1,9 @@
-from krita import Krita, Extension  # type: ignore
-from PyQt5.QtWidgets import QToolBar, QToolButton, QMenu
-from PyQt5 import QtGui
-from PyQt5.QtCore import QTimer, QObject, QEvent, Qt
+from krita import *
+from PyQt5.QtWidgets import QWidget, QAction, QComboBox,  QCheckBox, QVBoxLayout, QLineEdit, QPushButton, QLabel
+from PyQt5.QtCore import QSettings
 from functools import partial
+from pprint import pprint
 from .api_krita import Krita as KritaAPI
-from .api_krita.enums import Tool
 
 KRITA_ERASE_ACTION = "erase_action"
 BRUSH_ACTION = "dninosores_activate_brush"
@@ -13,22 +12,15 @@ ERASE_ON_ACTION = "dninosores_eraser_on"
 ERASE_OFF_ACTION = "dninosores_eraser_off"
 ERASE_TOGGLE_ACTION = "dninosores_eraser_toggle"
 MENU_LOCATION = "tools/scripts"
-MENU_GROUP_NAME = "SeparateBrushEraser"
 BRUSH_MODE = "BRUSH"
 ERASER_MODE = "ERASER"
 
-DEBUG = False
+DEBUG = True
 
 
 def print_dbg(msg):
     if DEBUG:
         print(msg)
-
-
-def get_action(name: str):
-    """Wrapper for non-type-safe getting action from Krita instance."""
-    return Krita.instance().action(name)
-
 
 class BrushSettings:
 
@@ -50,28 +42,39 @@ class BrushSettings:
 class BrushState:
     # Store a brush state for each view
     eraser_on: bool = False
-    brush_settings: BrushSettings | None = None
-    eraser_settings: BrushSettings | None = None
+    brush_settings: BrushSettings = None
+    eraser_settings: BrushSettings = None
 
 
 class SeparateBrushEraserExtension(Extension):
     brush_state = None
-    # Toggled on when the line tool is temporarily activated by modifier key
-    tmp_line_activation: bool = False
+    # In SeparateBrushEraserExtension class definition
+    settings = QSettings("ollyisonit", "SeparateBrushEraser")
+
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.filter = LineModifierFilter(self, Qt.Key.Key_Shift)
 
     def switch_to_brush(self):
-        KritaAPI.trigger_action("KritaShape/KisToolBrush")
+        Krita.instance().action("KritaShape/KisToolBrush").trigger()
 
     def eraser_active(self):
-        return get_action(KRITA_ERASE_ACTION).isChecked()
+        return Application.action(KRITA_ERASE_ACTION).isChecked()
+
+    # Big thanks to AkiR for helping with this function
+    def set_brush_preset_combo_box(self, tag):
+        app = Krita.instance()
+        win = app.activeWindow()
+        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
+        for combo_box in presets_docker.findChildren(QComboBox):
+            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
+                # print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
+                combo_box.setCurrentText(tag)
+                return  # correct one found, break loop with return
 
     def get_current_brush_state(self):
-        if (not KritaAPI.get_active_view() or not Krita.instance().
-                activeWindow().activeView().currentBrushPreset()):
+        if (not KritaAPI.get_active_view() or not Application.activeWindow().
+                activeView().currentBrushPreset()):
             return None
         if self.brush_state:
             return self.brush_state
@@ -91,68 +94,74 @@ class SeparateBrushEraserExtension(Extension):
         current_settings = BrushSettings().loadSettings()
         # toggling the eraser on
         if state.eraser_on:
-            if state.eraser_settings:
-                state.eraser_settings.applySettings()
+            state.eraser_settings.applySettings()
             state.brush_settings = current_settings
         else:
             state.eraser_settings = current_settings
-            if state.brush_settings:
-                state.brush_settings.applySettings()
+            state.brush_settings.applySettings()
         self.verify_eraser_state()
         return state
 
     def apply_current_brush_state(self):
-        state = self.get_current_brush_state()
-        if state:
-            return self.apply_brush_state(state)
+        return self.apply_brush_state(self.get_current_brush_state())
 
     def activate_brush(self, switchTool=True):
+        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
+        brush_tag = self.settings.value("brush_dropdown", "")
+
         if not self.get_current_brush_state():
             return
-        self.get_current_brush_state().eraser_on = False  # type: ignore
+        if link_brush_tag:
+            self.set_brush_preset_combo_box(brush_tag)
+        self.get_current_brush_state().eraser_on = False
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def activate_eraser(self, switchTool=True):
+        link_brush_tag = self.settings.value("checkbox_state", False, type=bool)
+        eraser_tag = self.settings.value("eraser_dropdown", "")
+
         if not self.get_current_brush_state():
             return
-        self.get_current_brush_state().eraser_on = True  # type: ignore
+        # print("Switching to eraser mode")  # Added logging
+        if link_brush_tag:
+            self.set_brush_preset_combo_box(eraser_tag)
+        self.get_current_brush_state().eraser_on = True
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def on_brush_toggled(self, toggled):
-        current_brush_state = self.get_current_brush_state()
-        if not current_brush_state:
+        if not self.get_current_brush_state():
             return
         # Triggers when krita switches to/from the brush tool for any reason. Does not trigger if the brush tool is already selected.
         if toggled:
             pass
-        # Don't switch eraser state if we're activating the line tool temporarily with modifier key
-        elif self.tmp_line_activation:
+        elif QApplication.queryKeyboardModifiers() & Qt.ShiftModifier:
             pass
+            print("Keeping eraser on bc shift is down")
         else:
-            current_brush_state.eraser_on = False
+            print("Turning off eraser bc shift is not down")
+            self.get_current_brush_state().eraser_on = False
             self.apply_current_brush_state()
 
     def verify_eraser_state(self):
-        current_brush_state = self.get_current_brush_state()
-        if current_brush_state:
-            desired_state = current_brush_state.eraser_on
+        if self.get_current_brush_state():
+            desired_state = self.get_current_brush_state().eraser_on
             if desired_state != self.eraser_active():
-                KritaAPI.trigger_action(KRITA_ERASE_ACTION)
+                Application.action(KRITA_ERASE_ACTION).trigger()
 
     def on_eraser_action(self, toggled):
         pass
         # self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
+        print("changed to the eraser")
 
     def classic_krita_eraser_toggle_auto(self):
-        if self.brush_state:
-            self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
+        self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
 
     def classic_krita_eraser_toggle(self, toggled):
         # self.verify_eraser_state()
@@ -163,51 +172,52 @@ class SeparateBrushEraserExtension(Extension):
             self.activate_brush(False)
 
     def on_eraser_button_clicked(self, toggled):
-        # print(f"Clicked with value {toggled}")
+        print(f"Clicked with value {toggled}")
         # Actually I think it would be better if this toggled like regular krita
         # i.e. swap the brush presets, then toggle eraser without switching tool
         # actually don't swap the brush presets but to toggle eraser without switching tool
         self.classic_krita_eraser_toggle(toggled)
 
     def on_eraser_button_toggled(self, toggled):
-        # print(f"Button toggled with value {toggled}")'
-        eraser_button = self.get_eraser_button()
-        if eraser_button:
-            eraser_button.setChecked(self.eraser_active())
+        print(f"Button toggled with value {toggled}")
+        self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
 
     def setup(self):
         pass
 
-    def createActions(self, window):
+    def open_settings_window(self):
+        self.settings_window = SettingsWindow()
+        self.settings_window.show()
 
-        # menu = QMenu(MENU_GROUP_NAME, window.qwindow())
+    def createActions(self, window):
+        # Add this new action with the existing actions
+        settings_action = window.createAction(
+            "dninosores_brush_eraser_settings",
+            "Brush Eraser Settings",
+            MENU_LOCATION)
+        settings_action.triggered.connect(self.open_settings_window)
+        
         # actions should be:
         # Switch to brush / switch to eraser, which activate the brush tool
         # Activate brush / eraser, which switch without activating the brush tool
         # Toggle, which toggles between the two options without switching the tool
         # A 'when you hold shift temporarily switch to the line tool without deactivating eraser' action
-        menu_action = window.createAction(
-            MENU_GROUP_NAME, MENU_GROUP_NAME,
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        menu = QMenu(MENU_GROUP_NAME, window.qwindow())
-        menu_action.setMenu(menu)
-        activate_brush_action = window.createAction(
-            BRUSH_ACTION, "Switch to Freehand Brush",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        activate_eraser_action = window.createAction(
-            ERASE_ACTION, "Switch to Freehand Eraser",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        enable_eraser_action = window.createAction(
-            ERASE_ON_ACTION, "Activate Eraser Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        disable_eraser_action = window.createAction(
-            ERASE_OFF_ACTION, "Activate Brush Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        toggle_eraser_action = window.createAction(
-            ERASE_TOGGLE_ACTION, "Toggle Eraser Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-
+        activate_brush_action = window.createAction(BRUSH_ACTION,
+                                                    "Switch to Brush",
+                                                    MENU_LOCATION)
+        activate_eraser_action = window.createAction(ERASE_ACTION,
+                                                     "Switch to Eraser",
+                                                     MENU_LOCATION)
+        enable_eraser_action = window.createAction(ERASE_ON_ACTION,
+                                                   "Activate Eraser",
+                                                   MENU_LOCATION)
+        disable_eraser_action = window.createAction(ERASE_OFF_ACTION,
+                                                    "Deactivate Eraser",
+                                                    MENU_LOCATION)
+        toggle_eraser_action = window.createAction(ERASE_TOGGLE_ACTION,
+                                                   "Toggle Eraser",
+                                                   MENU_LOCATION)
         activate_brush_action.triggered.connect(
             partial(self.activate_brush, True))
         activate_eraser_action.triggered.connect(
@@ -219,49 +229,32 @@ class SeparateBrushEraserExtension(Extension):
         toggle_eraser_action.triggered.connect(
             self.classic_krita_eraser_toggle_auto)
 
-        appNotifier = KritaAPI.instance.notifier()
-        appNotifier.setActive(True)
-
-        def installLineModifierFilter(_view: QObject):
-            for item, level in IterHierarchy(
-                    KritaAPI.instance.activeWindow().qwindow()):
-                if item.metaObject().className() == "Viewport":
-                    print_dbg("Installing line modifier filter")
-                    item.removeEventFilter(self.filter)
-                    item.installEventFilter(self.filter)
-
-        appNotifier.viewCreated.connect(installLineModifierFilter)
-
         QTimer.singleShot(500, self.bind_brush_toggled)
 
-    def get_eraser_button(self) -> QToolButton | None:
-        qwin = KritaAPI.get_active_qwindow()
+    def get_eraser_button(self):
+        qwin = Application.activeWindow().qwindow()
         pobj = qwin.findChild(QToolBar, 'BrushesAndStuff')
         eraser_button = None
         for item, depth in IterHierarchy(pobj):
             try:
-                if item.defaultAction() == get_action(KRITA_ERASE_ACTION):
+                if item.defaultAction() == Application.action(
+                        KRITA_ERASE_ACTION):
                     eraser_button = item
-            except Exception:
+            except:
                 pass
         return eraser_button
 
     def print_state(self):
-        current_brush_state = self.get_current_brush_state()
-        eraser_button = self.get_eraser_button()
-        if current_brush_state:
-            desired_state = current_brush_state.eraser_on
+        if self.get_current_brush_state():
+            desired_state = self.get_current_brush_state().eraser_on
             print(f"Eraser should be {desired_state}")
-            if eraser_button:
-                print(f"Button checked is {eraser_button.isChecked()}")
-            else:
-                print("Eraser button not found!")
+            print(f"Button checked is {self.get_eraser_button().isChecked()}")
             print(f"Eraser action is {self.eraser_active()}")
             print("\n")
 
     def bind_brush_toggled(self):
         success = False
-        Krita.instance().action(KRITA_ERASE_ACTION).triggered.connect(
+        Application.action(KRITA_ERASE_ACTION).triggered.connect(
             self.on_eraser_action)
         for docker in Krita.instance().dockers():
             if docker.objectName() == "ToolBox":
@@ -275,44 +268,13 @@ class SeparateBrushEraserExtension(Extension):
                 "Binding eraser toggle to brush button failed. Try restarting Krita."
             )
         eraser_button = self.get_eraser_button()
-        if eraser_button:
-            eraser_button.toggled.connect(self.on_eraser_button_toggled)
-            eraser_button.clicked.connect(self.on_eraser_button_clicked)
-        else:
-            print(
-                "Binding eraser toggle to erase button failed. Try restarting Krita."
-            )
-        timer = QTimer(KritaAPI.get_active_qwindow())
+
+        eraser_button.toggled.connect(self.on_eraser_button_toggled)
+        eraser_button.clicked.connect(self.on_eraser_button_clicked)
+
+        timer = QTimer(Application.activeWindow().qwindow())
         timer.timeout.connect(self.verify_eraser_state)
         timer.start(1)
-
-
-class LineModifierFilter(QObject):
-    """EventFilter that listens for a certain modifier key and tells the extension to temporarily switch to the line tool when it the key is pressed."""
-    extension: SeparateBrushEraserExtension
-    modifier_key: int = Qt.Key.Key_Shift
-
-    def __init__(self, extension: SeparateBrushEraserExtension,
-                 modifier_key: int):
-        super().__init__()
-        self.extension = extension
-        self.modifier_key = modifier_key
-
-    def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
-        event = a1
-        if event and isinstance(event, QtGui.QKeyEvent):
-            if KritaAPI.active_tool == Tool.FREEHAND_BRUSH and event.key(
-            ) == self.modifier_key and event.type() == QEvent.Type.KeyPress:
-                print_dbg("event filter activated")
-                self.extension.tmp_line_activation = True
-                KritaAPI.active_tool = Tool.LINE
-            if KritaAPI.active_tool == Tool.LINE and event.key(
-            ) == self.modifier_key and event.type() == QEvent.Type.KeyRelease:
-                print_dbg("event filter activated")
-                if self.extension.tmp_line_activation:
-                    KritaAPI.active_tool = Tool.FREEHAND_BRUSH
-                    self.extension.tmp_line_activation = False
-        return False
 
 
 class IterHierarchy:
@@ -341,3 +303,75 @@ class IterHierarchy:
 
 
 Krita.instance().addExtension(SeparateBrushEraserExtension(Krita.instance()))
+
+# Add after imports, before other classes
+class SettingsWindow(QWidget):
+    
+    def read_brush_preset_combo_box(self):
+        app = Krita.instance()
+        win = app.activeWindow()
+        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
+        for combo_box in presets_docker.findChildren(QComboBox):
+            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
+                return [combo_box.itemText(i) for i in range(combo_box.count())]
+
+    def __init__(self):
+        super().__init__()
+        preset_tags = self.read_brush_preset_combo_box()
+        self.settings = QSettings("ollyisonit", "SeparateBrushEraser")
+        self.setWindowTitle("Separate Brush Eraser Settings")
+        # Removed setGeometry – we’ll let size policies handle layout
+        # self.setGeometry(100, 100, 300, 200)
+
+        main_layout = QVBoxLayout()
+
+        # Checkbox
+        self.checkbox = QCheckBox("Link a brush preset tag with the brush and eraser")
+        self.checkbox.setChecked(self.settings.value("checkbox_state", False, type=bool))
+        self.checkbox.stateChanged.connect(self.on_checkbox_state_changed)
+        main_layout.addWidget(self.checkbox)
+
+        # Brush section
+        brush_label = QLabel("Brush preset tag to link with brushes:")
+        self.brush_dropdown = QComboBox()
+        self.brush_dropdown.addItems(preset_tags)
+        saved_brush = self.settings.value("brush_dropdown", "")
+        if saved_brush and saved_brush in preset_tags:
+            self.brush_dropdown.setCurrentText(saved_brush)
+        self.brush_dropdown.currentTextChanged.connect(self.on_brush_changed)
+
+        # Apply fixed size policy
+        brush_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.brush_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        main_layout.addWidget(brush_label)
+        main_layout.addWidget(self.brush_dropdown)
+
+        # Eraser section
+        eraser_label = QLabel("Brush preset tag to link with erasers:")
+        self.eraser_dropdown = QComboBox()
+        self.eraser_dropdown.addItems(preset_tags)
+        saved_eraser = self.settings.value("eraser_dropdown", "")
+        if saved_eraser and saved_eraser in preset_tags:
+            self.eraser_dropdown.setCurrentText(saved_eraser)
+        self.eraser_dropdown.currentTextChanged.connect(self.on_eraser_changed)
+
+        # Apply fixed size policy
+        eraser_label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.eraser_dropdown.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+
+        main_layout.addWidget(eraser_label)
+        main_layout.addWidget(self.eraser_dropdown)
+
+        # Set layout and let it autosize
+        self.setLayout(main_layout)
+        self.adjustSize()
+
+    def on_checkbox_state_changed(self, state):
+        self.settings.setValue("checkbox_state", bool(state))
+
+    def on_brush_changed(self, value):
+        self.settings.setValue("brush_dropdown", value)
+
+    def on_eraser_changed(self, value):
+        self.settings.setValue("eraser_dropdown", value)

--- a/separatebrusheraser/separatebrusheraser.py
+++ b/separatebrusheraser/separatebrusheraser.py
@@ -1,10 +1,8 @@
-from krita import Krita, Extension  # type: ignore
-from PyQt5.QtWidgets import QToolBar, QToolButton, QMenu
-from PyQt5 import QtGui
-from PyQt5.QtCore import QTimer, QObject, QEvent, Qt
+from krita import *
+from PyQt5.QtWidgets import QWidget, QAction, QComboBox
 from functools import partial
+from pprint import pprint
 from .api_krita import Krita as KritaAPI
-from .api_krita.enums import Tool
 
 KRITA_ERASE_ACTION = "erase_action"
 BRUSH_ACTION = "dninosores_activate_brush"
@@ -13,22 +11,16 @@ ERASE_ON_ACTION = "dninosores_eraser_on"
 ERASE_OFF_ACTION = "dninosores_eraser_off"
 ERASE_TOGGLE_ACTION = "dninosores_eraser_toggle"
 MENU_LOCATION = "tools/scripts"
-MENU_GROUP_NAME = "SeparateBrushEraser"
 BRUSH_MODE = "BRUSH"
 ERASER_MODE = "ERASER"
 
-DEBUG = False
+DEBUG = True
 
 
 def print_dbg(msg):
     if DEBUG:
         print(msg)
-
-
-def get_action(name: str):
-    """Wrapper for non-type-safe getting action from Krita instance."""
-    return Krita.instance().action(name)
-
+        print("hello World!")
 
 class BrushSettings:
 
@@ -50,28 +42,36 @@ class BrushSettings:
 class BrushState:
     # Store a brush state for each view
     eraser_on: bool = False
-    brush_settings: BrushSettings | None = None
-    eraser_settings: BrushSettings | None = None
+    brush_settings: BrushSettings = None
+    eraser_settings: BrushSettings = None
 
 
 class SeparateBrushEraserExtension(Extension):
     brush_state = None
-    # Toggled on when the line tool is temporarily activated by modifier key
-    tmp_line_activation: bool = False
 
     def __init__(self, parent):
         super().__init__(parent)
-        self.filter = LineModifierFilter(self, Qt.Key.Key_Shift)
 
     def switch_to_brush(self):
-        KritaAPI.trigger_action("KritaShape/KisToolBrush")
+        Krita.instance().action("KritaShape/KisToolBrush").trigger()
 
     def eraser_active(self):
-        return get_action(KRITA_ERASE_ACTION).isChecked()
+        return Application.action(KRITA_ERASE_ACTION).isChecked()
+
+    # Big thankts to AkiR for helping with this function!
+    def set_brush_preset_combo_box(self, tag):
+        app = Krita.instance()
+        win = app.activeWindow()
+        presets_docker = next((d for d in win.dockers() if d.objectName() == 'PresetDocker'), None)
+        for combo_box in presets_docker.findChildren(QComboBox):
+            if combo_box.parent().metaObject().className() == 'KisTagChooserWidget':
+                print('Debug: ' + ', '.join(combo_box.itemText(i) for i in range(combo_box.count())))
+                combo_box.setCurrentText(tag)
+                return  # correct one found, break loop with return
 
     def get_current_brush_state(self):
-        if (not KritaAPI.get_active_view() or not Krita.instance().
-                activeWindow().activeView().currentBrushPreset()):
+        if (not KritaAPI.get_active_view() or not Application.activeWindow().
+                activeView().currentBrushPreset()):
             return None
         if self.brush_state:
             return self.brush_state
@@ -91,25 +91,24 @@ class SeparateBrushEraserExtension(Extension):
         current_settings = BrushSettings().loadSettings()
         # toggling the eraser on
         if state.eraser_on:
-            if state.eraser_settings:
-                state.eraser_settings.applySettings()
+            state.eraser_settings.applySettings()
             state.brush_settings = current_settings
         else:
             state.eraser_settings = current_settings
-            if state.brush_settings:
-                state.brush_settings.applySettings()
+            state.brush_settings.applySettings()
         self.verify_eraser_state()
         return state
 
     def apply_current_brush_state(self):
-        state = self.get_current_brush_state()
-        if state:
-            return self.apply_brush_state(state)
+        return self.apply_brush_state(self.get_current_brush_state())
 
     def activate_brush(self, switchTool=True):
         if not self.get_current_brush_state():
             return
-        self.get_current_brush_state().eraser_on = False  # type: ignore
+        print("Switching to brush mode")
+        # set_brush_preset_combo_box('Digital')
+        self.set_brush_preset_combo_box('Brushes')
+        self.get_current_brush_state().eraser_on = False
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
@@ -118,41 +117,42 @@ class SeparateBrushEraserExtension(Extension):
     def activate_eraser(self, switchTool=True):
         if not self.get_current_brush_state():
             return
-        self.get_current_brush_state().eraser_on = True  # type: ignore
+        print("Switching to eraser mode")  # Added logging
+        self.set_brush_preset_combo_box('Erasers')
+        self.get_current_brush_state().eraser_on = True
         if switchTool:
             self.switch_to_brush()
         self.apply_current_brush_state()
         QTimer.singleShot(0, self.verify_eraser_state)
 
     def on_brush_toggled(self, toggled):
-        current_brush_state = self.get_current_brush_state()
-        if not current_brush_state:
+        if not self.get_current_brush_state():
             return
         # Triggers when krita switches to/from the brush tool for any reason. Does not trigger if the brush tool is already selected.
         if toggled:
             pass
-        # Don't switch eraser state if we're activating the line tool temporarily with modifier key
-        elif self.tmp_line_activation:
+        elif QApplication.queryKeyboardModifiers() & Qt.ShiftModifier:
             pass
+            print("Keeping eraser on bc shift is down")
         else:
-            current_brush_state.eraser_on = False
+            print("Turning off eraser bc shift is not down")
+            self.get_current_brush_state().eraser_on = False
             self.apply_current_brush_state()
 
     def verify_eraser_state(self):
-        current_brush_state = self.get_current_brush_state()
-        if current_brush_state:
-            desired_state = current_brush_state.eraser_on
+        if self.get_current_brush_state():
+            desired_state = self.get_current_brush_state().eraser_on
             if desired_state != self.eraser_active():
-                KritaAPI.trigger_action(KRITA_ERASE_ACTION)
+                Application.action(KRITA_ERASE_ACTION).trigger()
 
     def on_eraser_action(self, toggled):
         pass
         # self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
+        print("changed to the eraser")
 
     def classic_krita_eraser_toggle_auto(self):
-        if self.brush_state:
-            self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
+        self.classic_krita_eraser_toggle(not self.brush_state.eraser_on)
 
     def classic_krita_eraser_toggle(self, toggled):
         # self.verify_eraser_state()
@@ -163,51 +163,41 @@ class SeparateBrushEraserExtension(Extension):
             self.activate_brush(False)
 
     def on_eraser_button_clicked(self, toggled):
-        # print(f"Clicked with value {toggled}")
+        print(f"Clicked with value {toggled}")
         # Actually I think it would be better if this toggled like regular krita
         # i.e. swap the brush presets, then toggle eraser without switching tool
         # actually don't swap the brush presets but to toggle eraser without switching tool
         self.classic_krita_eraser_toggle(toggled)
 
     def on_eraser_button_toggled(self, toggled):
-        # print(f"Button toggled with value {toggled}")'
-        eraser_button = self.get_eraser_button()
-        if eraser_button:
-            eraser_button.setChecked(self.eraser_active())
+        print(f"Button toggled with value {toggled}")
+        self.get_eraser_button().setChecked(self.eraser_active())
         # self.verify_eraser_state()
 
     def setup(self):
         pass
 
     def createActions(self, window):
-
-        # menu = QMenu(MENU_GROUP_NAME, window.qwindow())
         # actions should be:
         # Switch to brush / switch to eraser, which activate the brush tool
         # Activate brush / eraser, which switch without activating the brush tool
         # Toggle, which toggles between the two options without switching the tool
         # A 'when you hold shift temporarily switch to the line tool without deactivating eraser' action
-        menu_action = window.createAction(
-            MENU_GROUP_NAME, MENU_GROUP_NAME,
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        menu = QMenu(MENU_GROUP_NAME, window.qwindow())
-        menu_action.setMenu(menu)
-        activate_brush_action = window.createAction(
-            BRUSH_ACTION, "Switch to Freehand Brush",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        activate_eraser_action = window.createAction(
-            ERASE_ACTION, "Switch to Freehand Eraser",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        enable_eraser_action = window.createAction(
-            ERASE_ON_ACTION, "Activate Eraser Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        disable_eraser_action = window.createAction(
-            ERASE_OFF_ACTION, "Activate Brush Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-        toggle_eraser_action = window.createAction(
-            ERASE_TOGGLE_ACTION, "Toggle Eraser Preset for Current Tool",
-            MENU_LOCATION + "/" + MENU_GROUP_NAME)
-
+        activate_brush_action = window.createAction(BRUSH_ACTION,
+                                                    "Switch to Brush",
+                                                    MENU_LOCATION)
+        activate_eraser_action = window.createAction(ERASE_ACTION,
+                                                     "Switch to Eraser",
+                                                     MENU_LOCATION)
+        enable_eraser_action = window.createAction(ERASE_ON_ACTION,
+                                                   "Activate Eraser",
+                                                   MENU_LOCATION)
+        disable_eraser_action = window.createAction(ERASE_OFF_ACTION,
+                                                    "Deactivate Eraser",
+                                                    MENU_LOCATION)
+        toggle_eraser_action = window.createAction(ERASE_TOGGLE_ACTION,
+                                                   "Toggle Eraser",
+                                                   MENU_LOCATION)
         activate_brush_action.triggered.connect(
             partial(self.activate_brush, True))
         activate_eraser_action.triggered.connect(
@@ -219,49 +209,32 @@ class SeparateBrushEraserExtension(Extension):
         toggle_eraser_action.triggered.connect(
             self.classic_krita_eraser_toggle_auto)
 
-        appNotifier = KritaAPI.instance.notifier()
-        appNotifier.setActive(True)
-
-        def installLineModifierFilter(_view: QObject):
-            for item, level in IterHierarchy(
-                    KritaAPI.instance.activeWindow().qwindow()):
-                if item.metaObject().className() == "Viewport":
-                    print_dbg("Installing line modifier filter")
-                    item.removeEventFilter(self.filter)
-                    item.installEventFilter(self.filter)
-
-        appNotifier.viewCreated.connect(installLineModifierFilter)
-
         QTimer.singleShot(500, self.bind_brush_toggled)
 
-    def get_eraser_button(self) -> QToolButton | None:
-        qwin = KritaAPI.get_active_qwindow()
+    def get_eraser_button(self):
+        qwin = Application.activeWindow().qwindow()
         pobj = qwin.findChild(QToolBar, 'BrushesAndStuff')
         eraser_button = None
         for item, depth in IterHierarchy(pobj):
             try:
-                if item.defaultAction() == get_action(KRITA_ERASE_ACTION):
+                if item.defaultAction() == Application.action(
+                        KRITA_ERASE_ACTION):
                     eraser_button = item
-            except Exception:
+            except:
                 pass
         return eraser_button
 
     def print_state(self):
-        current_brush_state = self.get_current_brush_state()
-        eraser_button = self.get_eraser_button()
-        if current_brush_state:
-            desired_state = current_brush_state.eraser_on
+        if self.get_current_brush_state():
+            desired_state = self.get_current_brush_state().eraser_on
             print(f"Eraser should be {desired_state}")
-            if eraser_button:
-                print(f"Button checked is {eraser_button.isChecked()}")
-            else:
-                print("Eraser button not found!")
+            print(f"Button checked is {self.get_eraser_button().isChecked()}")
             print(f"Eraser action is {self.eraser_active()}")
             print("\n")
 
     def bind_brush_toggled(self):
         success = False
-        Krita.instance().action(KRITA_ERASE_ACTION).triggered.connect(
+        Application.action(KRITA_ERASE_ACTION).triggered.connect(
             self.on_eraser_action)
         for docker in Krita.instance().dockers():
             if docker.objectName() == "ToolBox":
@@ -275,44 +248,13 @@ class SeparateBrushEraserExtension(Extension):
                 "Binding eraser toggle to brush button failed. Try restarting Krita."
             )
         eraser_button = self.get_eraser_button()
-        if eraser_button:
-            eraser_button.toggled.connect(self.on_eraser_button_toggled)
-            eraser_button.clicked.connect(self.on_eraser_button_clicked)
-        else:
-            print(
-                "Binding eraser toggle to erase button failed. Try restarting Krita."
-            )
-        timer = QTimer(KritaAPI.get_active_qwindow())
+
+        eraser_button.toggled.connect(self.on_eraser_button_toggled)
+        eraser_button.clicked.connect(self.on_eraser_button_clicked)
+
+        timer = QTimer(Application.activeWindow().qwindow())
         timer.timeout.connect(self.verify_eraser_state)
         timer.start(1)
-
-
-class LineModifierFilter(QObject):
-    """EventFilter that listens for a certain modifier key and tells the extension to temporarily switch to the line tool when it the key is pressed."""
-    extension: SeparateBrushEraserExtension
-    modifier_key: int = Qt.Key.Key_Shift
-
-    def __init__(self, extension: SeparateBrushEraserExtension,
-                 modifier_key: int):
-        super().__init__()
-        self.extension = extension
-        self.modifier_key = modifier_key
-
-    def eventFilter(self, a0: QObject | None, a1: QEvent | None) -> bool:
-        event = a1
-        if event and isinstance(event, QtGui.QKeyEvent):
-            if KritaAPI.active_tool == Tool.FREEHAND_BRUSH and event.key(
-            ) == self.modifier_key and event.type() == QEvent.Type.KeyPress:
-                print_dbg("event filter activated")
-                self.extension.tmp_line_activation = True
-                KritaAPI.active_tool = Tool.LINE
-            if KritaAPI.active_tool == Tool.LINE and event.key(
-            ) == self.modifier_key and event.type() == QEvent.Type.KeyRelease:
-                print_dbg("event filter activated")
-                if self.extension.tmp_line_activation:
-                    KritaAPI.active_tool = Tool.FREEHAND_BRUSH
-                    self.extension.tmp_line_activation = False
-        return False
 
 
 class IterHierarchy:


### PR DESCRIPTION
Hello! This is my implementation of a feature I had requested to be added. It adds a new settings panel to let the user link a tag from the brush preset docker with the brush and eraser.
This is meant to emulate the functionality of the tool preset panel from Photoshop and how clip studio handles brushes, it's a feature I find very practical for keeping brushes and erasers organized and accessible with more ease.

By default the feature is turned off.

---
## Demonstration

https://github.com/user-attachments/assets/87fdc922-4bde-47db-b9ea-d18d061dbae4

